### PR TITLE
fix OSX process invocation and add cwd

### DIFF
--- a/util.js
+++ b/util.js
@@ -28,7 +28,7 @@ function getLCUExecutableFromProcess() {
 
 async function duplicateSystemYaml() {
     const LCUExePath = await getLCUExecutableFromProcess();
-    const LCUDir = path.dirname(LCUExePath);
+    const LCUDir = IS_WIN ? path.dirname(LCUExePath) : path.dirname(LCUExePath) + '/../../..';
 
     const originalSystemFile = path.join(LCUDir, 'system.yaml');
     const overrideSystemFile = path.join(LCUDir, 'Config', 'rift-explorer', 'system.yaml');
@@ -51,8 +51,9 @@ async function duplicateSystemYaml() {
 function restartLCUWithOverride(LCUData) {
     return new Promise(async (resolve, reject) => {
         const LCUExePath = await getLCUExecutableFromProcess();
-        const LCUDir = path.dirname(LCUExePath);
+        const LCUDir = IS_WIN ? path.dirname(LCUExePath) : path.dirname(LCUExePath) + '/../../..';
         const overrideSystemFile = path.join(LCUDir, 'Config', 'rift-explorer', 'system.yaml');
+    
         const { username, password, address, port } = LCUData;
         
         await requestPromise({
@@ -64,6 +65,7 @@ function restartLCUWithOverride(LCUData) {
         // Give it some time to do cleanup
         setTimeout(() => {
             const leagueProcess = spawn(LCUExePath.trim(), [`--system-yaml-override=${overrideSystemFile}`], {
+                cwd: LCUDir,
                 detached: true,
                 stdio: 'ignore'
             });


### PR DESCRIPTION
first off, the `LCUExePath` as reported by OSX in the current version returns `/Applications/League of Legends.app/Contents/LoL/LeagueClient.app/Contents/MacOS/LeagueClient`, which is nested too far deep to find `system.yaml`;  only sadness lives here.  the proposed fix hackily traverses the tree three levels back to set `LCUDir` as the correct directory.

attempting to invoke the binary directly without setting the proper working directory leads to the application failing to find the plugin manifest, leading to the following error message:

https://i.imgur.com/gz0u0nE.png

as you can see from the following console dump, the application is trying to instantiate logging and load the plugin manifest from the `rift-explorer` directory that i cloned the repo into:
```
dg-grindrmbp:rift-explorer brycecasejr$ /Applications/League\ of\ Legends.app/Contents/LoL/LeagueClient.app/Contents/MacOS/LeagueClient --system-yaml-override="/Applications/League of Legends.app/Contents/LoL/Config/rift-explorer/system.yaml"
<unknown>(0x7fffcc12a3c0): ALWAYS| 'system.yaml' path override: '/Applications/League of Legends.app/Contents/LoL/Config/rift-explorer/system.yaml'
2019-06-16 08:34:59.323 LeagueClient[6233:724017] BugSplatFramework: initWithDatabase: defaultExceptionHandler is set
...
<unknown>(0x700000d44000): ALWAYS| Tracing CompactJsonWriter at /Users/brycecasejr/rift-explorer/Logs/LeagueClient Logs/2019-06-16T08-34-59_6233_LeagueClient-tracing.json
<unknown>(0x7fffcc12a3c0): ALWAYS| Phase Begin - Init
<unknown>(0x7fffcc12a3c0):  ERROR|             Plugin Manager| Could not load plugin manifest file plugin-manifest.json because: Could not open json file plugin-manifest.json.
<unknown>(0x7fffcc12a3c0): ALWAYS| Failed to init modules due to bad data.
...
```
setting the current working directory to the updated `LCUDir` allows the plugin manifest to properly load and the ancillary configuration like `local_settings_file: Config/LeagueClientSettings.yaml` to be viewed properly.

screenshot of it working: https://i.imgur.com/tYER4J9.png

we good now, fam.