### PR TITLE
Allow rift explorer to work even if the new Riot Client exists

### DIFF
--- a/util.js
+++ b/util.js
@@ -20,7 +20,7 @@ function getLCUExecutableFromProcess() {
                 return;
             }
 
-            const normalizedPath = path.normalize(stdout); 
+            const normalizedPath = path.normalize(stdout);
             resolve(IS_WIN ? normalizedPath.split(/\n|\n\r/)[1] : normalizedPath);
         });
     });
@@ -39,9 +39,10 @@ async function duplicateSystemYaml() {
     }
 
     const file = await fs.readFile(originalSystemFile, 'utf8');
-    const fileParsed = yaml.parse(file);
-    
-    fileParsed.enable_swagger = true;
+    const fileParsed = yaml.parseDocument(file);
+
+    fileParsed.delete("riotclient");
+    fileParsed.set(`enable_swagger`, true);
 
     const stringifiedFile = yaml.stringify(fileParsed);
     // Rito's file is prefixed with --- newline
@@ -53,15 +54,15 @@ function restartLCUWithOverride(LCUData) {
         const LCUExePath = await getLCUExecutableFromProcess();
         const LCUDir = IS_WIN ? path.dirname(LCUExePath) : path.dirname(LCUExePath) + '/../../..';
         const overrideSystemFile = path.join(LCUDir, 'Config', 'rift-explorer', 'system.yaml');
-    
+
         const { username, password, address, port } = LCUData;
-        
+
         await requestPromise({
             strictSSL: false,
-            method: 'POST', 
+            method: 'POST',
             uri: `https://${username}:${password}@${address}:${port}/process-control/v1/process/quit`,
         });
-        
+
         // Give it some time to do cleanup
         setTimeout(() => {
             const leagueProcess = spawn(LCUExePath.trim(), [`--system-yaml-override=${overrideSystemFile}`], {


### PR DESCRIPTION
By just bypassing it 🤷‍♀ 